### PR TITLE
Fix validation check and docstring typo

### DIFF
--- a/src/load_inputs/load_demand_data.jl
+++ b/src/load_inputs/load_demand_data.jl
@@ -119,7 +119,7 @@ function validatetimebasis(inputs::Dict)
     allequal(x) = all(y -> y == x[1], x)
     ok = allequal(check_equal)
 
-    if ~ok
+    if !ok
         error("""Critical error in time series construction:
                  lengths of the various time series, and/or the expected
                  total length based on the number of representative periods and their length,

--- a/src/time_domain_reduction/time_domain_reduction.jl
+++ b/src/time_domain_reduction/time_domain_reduction.jl
@@ -101,7 +101,7 @@ function parse_data(myinputs)
 end
 
 @doc raw"""
-    parse_mutli_period_data(inputs_dict)
+    parse_multi_stage_data(inputs_dict)
 
 Get demand, solar, wind, and other curves from multi-stage input data.
 


### PR DESCRIPTION
## Summary
- correct boolean check in `validatetimebasis`
- fix typo in docstring for multi-stage parsing

## Testing
- `julia --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68408c7f62bc8329a2148324024c3610