### PR TITLE
Fix random seed for stable tests

### DIFF
--- a/test/writing_outputs/test_writing_stats_ms.jl
+++ b/test/writing_outputs/test_writing_stats_ms.jl
@@ -3,6 +3,9 @@ module TestWritingStatsMs
 using Test
 using CSV, DataFrames
 using GenX
+using Random
+
+Random.seed!(1234)
 
 # create temporary directory for testing 
 mkpath("writing_outputs/multi_stage_stats_tmp")


### PR DESCRIPTION
## Summary
- seed `Random` in multi-stage stats tests for reproducible runs

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: `julia: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68408eee94948329acf628fb5b869f63