### PR TITLE
Add inertia requirement constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ The 'main' branch is the current master branch of GenX. The various subdirectori
 
 3. `docs/` Contains source files for documentation pertaining to the model.
 
+## Inertia Branch
+
+This branch includes an optional system inertia constraint. Users must provide a
+new `inertia_req.csv` file and add an `MW_s_per_MW` column to each resource input
+table. Configuration flag `InertiaRequirement` enables the constraint and
+`WriteInertia` controls output of hourly inertia values. See `README_inertia.md`
+for details.
+
 ## Requirements
 
 GenX (v0.4.4) runs on Julia v1.6 through v1.9, with a minimum version of the package JuMP v1.1.1. Julia v1.10 and v1.11 are also supported. However, we recently noticed a decline in performance with Julia v1.10, which is currently under investigation. Therefore, **we recommend using Julia v1.9**, particularly for very large cases.

--- a/README_inertia.md
+++ b/README_inertia.md
@@ -1,0 +1,19 @@
+# Inertia Branch Usage
+
+This branch introduces an optional system inertia constraint. To use it you need to provide new input data and settings beyond those required in the main GenX branch.
+
+## New Settings
+
+- `InertiaRequirement`: set to `1` in `genx_settings.yml` to activate the inertia constraint.
+- `WriteInertia`: set in the output settings to write hourly inertia values to the outputs folder.
+
+## New Input Data
+
+1. **Resource tables** – every resource file must include a column `MW_s_per_MW` specifying the amount of inertia (in MW‑s) contributed per MW of online capacity.
+2. **inertia_req.csv** – inside each period's `policies` folder (`inputs/inputs_pX/policies`). This file contains one column `MW_s` listing the required system inertia for each modeled hour. When using Time Domain Reduction, the reduction routine writes a shortened version of this file to `TDR_results/inertia_req.csv`.
+
+## Outputs
+
+When `WriteInertia` is enabled the model writes `inertia.csv` in the standard output directory. The file records the hourly inertia provided by each resource, scaled to match the full time series if `OutputFullTimeSeries` is used.
+
+These additions are the only differences from the original GenX repository.

--- a/docs/src/User_Guide/model_input.md
+++ b/docs/src/User_Guide/model_input.md
@@ -181,6 +181,7 @@ Each file contains cost and performance parameters for various generators and ot
 ||Retrofit = 0: is not a retrofit technology.|
 |Retrofit\_Id | Unique identifier to group retrofittable source technologies with retrofit options inside the same zone.|
 |Retrofit\_Efficiency | [0,1], Efficiency of the retrofit technology.|
+|MW_s_per_MW|Amount of inertia contributed by each MW of capacity while online (MW-s/MW). Required when `InertiaRequirement` is used.|
 
 ##### Table 5b: Settings-specific columns in all resource .csv file
 ---
@@ -235,6 +236,7 @@ Each file contains cost and performance parameters for various generators and ot
 |Fuel2\_Min\_Cofire_Level\_Start  |The minimum blendng level of 'Fuel2' in total heat inputs of a mulit-fuel generator (MULTI_FUELS = 1) during the start-up process. |
 |Fuel2\_Max\_Cofire\_Level  |The maximum blendng level of 'Fuel2' in total heat inputs of a mulit-fuel generator (MULTI_FUELS = 1) during the normal generation process. |
 |Fuel2\_Max\_Cofire_Level\_Start  |The maximum blendng level of 'Fuel2' in total heat inputs of a mulit-fuel generator (MULTI_FUELS = 1) during the start-up process. |
+|MW_s_per_MW|Amount of inertia contributed by each MW of capacity while online (MW-s/MW). Required when `InertiaRequirement` is used. |
 
 ##### Table 6b: Settings-specific columns in the Thermal.csv file
 ---
@@ -789,3 +791,13 @@ This file contains inputs specifying regional hydrogen production requirements. 
 |Constraint\_Description| Names of hydrogen demand constraints; not to be read by model, but used as a helpful notation to the model user. |
 |Hydrogen\_Demand\_kt| Hydrogen production requirements in 1,000 tons|
 |PriceCap| Price of hydrogen per metric ton ($/t)|
+
+### 2.9 inertia_req.csv
+
+This optional file specifies the minimum system inertia requirement for each period. It is required when the setting `InertiaRequirement` is set to 1 in `genx_settings.yml`.
+
+###### Table 28: Structure of the inertia_req.csv file
+---
+|**Column Name** | **Description**|
+| :------------ | :-----------|
+|MW_s|System inertia requirement in megawatt-seconds that must be met in every modeled hour|

--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -45,7 +45,9 @@ function time_domain_reduced_files_exist(tdrpath)
     tdr_demand = file_exists(tdrpath, ["Demand_data.csv", "Load_data.csv"])
     tdr_genvar = isfile(joinpath(tdrpath, "Generators_variability.csv"))
     tdr_fuels = isfile(joinpath(tdrpath, "Fuels_data.csv"))
-    return (tdr_demand && tdr_genvar && tdr_fuels)
+    inertia_src = joinpath(dirname(tdrpath), "policies", "inertia_req.csv")
+    tdr_inertia = !isfile(inertia_src) || isfile(joinpath(tdrpath, "inertia_req.csv"))
+    return (tdr_demand && tdr_genvar && tdr_fuels && tdr_inertia)
 end
 
 function run_genx_case_simple!(case::AbstractString, mysetup::Dict, optimizer::Any)

--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -29,6 +29,7 @@ function default_settings()
         "EnableJuMPStringNames" => false,
         "HourlyMatching" => 0,
         "HydrogenHourlyMatching" => 0,
+        "InertiaRequirement" => 0,
         "DC_OPF" => 0,
         "WriteOutputs" => "full",
         "ComputeConflicts" => 0,
@@ -144,7 +145,8 @@ function default_writeoutput()
         "WriteTransmissionLosses" => true,
         "WriteVirtualDischarge" => true,
         "WriteVREStor" => true,
-        "WriteAngles" => true)
+        "WriteAngles" => true,
+        "WriteInertia" => true)
 end
 
 function configure_writeoutput(output_settings_path::String, settings::Dict)

--- a/src/load_inputs/load_inertia_requirement.jl
+++ b/src/load_inputs/load_inertia_requirement.jl
@@ -1,0 +1,25 @@
+@doc raw"""
+    load_inertia_requirement!(setup::Dict, path::AbstractString, inputs::Dict)
+
+Read input parameters for system inertia requirements. The file `inertia_req.csv`
+should contain a single column `MW_s` with the minimum inertia (in megawatt-seconds)
+that must be available each modeled hour.
+"""
+function load_inertia_requirement!(setup::Dict, path::AbstractString, inputs::Dict)
+    filename = "inertia_req.csv"
+    # `path` is typically the policies directory. If time domain reduction
+    # was performed and a reduced file exists, read that instead.
+    casepath = dirname(path)
+    tdr_dir = joinpath(casepath, setup["TimeDomainReductionFolder"])
+    if setup["TimeDomainReduction"] == 1 && isfile(joinpath(tdr_dir, filename))
+        df = load_dataframe(joinpath(tdr_dir, filename))
+    else
+        df = load_dataframe(joinpath(path, filename))
+    end
+    req = Vector{Float64}(df[:, :MW_s])
+    scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1.0
+    req ./= scale_factor # convert to GW-s if scaled
+    inputs["InertiaReq"] = req
+    println(filename * " Successfully Read!")
+    return nothing
+end

--- a/src/load_inputs/load_inputs.jl
+++ b/src/load_inputs/load_inputs.jl
@@ -75,6 +75,10 @@ function load_inputs(setup::Dict, path::AbstractString)
         load_hydrogen_demand!(setup, policies_path, inputs)
     end
 
+    if setup["InertiaRequirement"] == 1
+        load_inertia_requirement!(setup, policies_path, inputs)
+    end
+
     # Read in mapping of modeled periods to representative periods
     if is_period_map_necessary(inputs) && is_period_map_exist(setup, path)
         load_period_map!(setup, path, inputs)

--- a/src/model/generate_model.jl
+++ b/src/model/generate_model.jl
@@ -119,6 +119,10 @@ function generate_model(setup::Dict, inputs::Dict, OPTIMIZER::MOI.OptimizerWithA
         create_empty_expression!(EP, :eH2DemandRes, inputs["NumberOfH2DemandReqs"])
     end
 
+    if setup["InertiaRequirement"] == 1
+        create_empty_expression!(EP, :eInertiaBalance, T)
+    end
+
     # Infrastructure
     discharge!(EP, inputs, setup)
 
@@ -199,6 +203,10 @@ function generate_model(setup::Dict, inputs::Dict, OPTIMIZER::MOI.OptimizerWithA
        (!isempty(inputs["VRE_STOR"]) && !isempty(inputs["VS_ELEC"]))
         electrolyzer!(EP, inputs, setup)
     end
+
+    if setup["InertiaRequirement"] == 1
+        resource_inertia!(EP, inputs, setup)
+    end
     # Policies
 
     if setup["OperationalReserves"] > 0
@@ -241,6 +249,10 @@ function generate_model(setup::Dict, inputs::Dict, OPTIMIZER::MOI.OptimizerWithA
     # Hydrogen demand limits
     if setup["HydrogenMinimumProduction"] > 0
         hydrogen_demand!(EP, inputs, setup)
+    end
+
+    if setup["InertiaRequirement"] == 1
+        inertia_requirement!(EP, inputs, setup)
     end
 
     if setup["ModelingToGenerateAlternatives"] == 1

--- a/src/model/policies/inertia_requirement.jl
+++ b/src/model/policies/inertia_requirement.jl
@@ -1,0 +1,14 @@
+@doc raw"""
+    inertia_requirement!(EP::Model, inputs::Dict, setup::Dict)
+
+Enforces a system inertia requirement in each time step. The total inertia
+contributed by online units must be at least the value specified in
+`inertia_req.csv`.
+"""
+function inertia_requirement!(EP::Model, inputs::Dict, setup::Dict)
+    println("Inertia Requirement Module")
+    T = inputs["T"]
+    req = inputs["InertiaReq"]
+    nreq = length(req)
+    @constraint(EP, cInertiaReq[t = 1:T], EP[:eInertiaBalance][t] >= req[min(t, nreq)])
+end

--- a/src/model/resources/resource_inertia.jl
+++ b/src/model/resources/resource_inertia.jl
@@ -1,0 +1,22 @@
+function resource_inertia!(EP::Model, inputs::Dict, setup::Dict)
+    gen = inputs["RESOURCES"]
+    T = inputs["T"]
+    G = inputs["G"]
+    COMMIT = inputs["COMMIT"]
+    scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1.0
+    availability = inputs["pP_Max"]
+    if !isempty(COMMIT)
+        @expression(EP, eInertiaCommit[t in 1:T],
+            sum(EP[:vCOMMIT][y, t] * cap_size(gen[y]) * availability[y, t] *
+                scale_factor * mw_s_per_mw(gen[y]) for y in COMMIT))
+        add_similar_to_expression!(EP[:eInertiaBalance], eInertiaCommit)
+    end
+    NON_COMMIT = setdiff(1:G, COMMIT)
+    if !isempty(NON_COMMIT)
+        @expression(EP, eInertiaAlways[t in 1:T],
+            sum(EP[:eTotalCap][y] * availability[y, t] * scale_factor *
+                mw_s_per_mw(gen[y]) for y in NON_COMMIT))
+        add_similar_to_expression!(EP[:eInertiaBalance], eInertiaAlways)
+    end
+    return nothing
+end

--- a/src/model/resources/resources.jl
+++ b/src/model/resources/resources.jl
@@ -616,6 +616,7 @@ function fixed_om_cost_charge_per_mwyr(r::AbstractResource)
     get(r, :fixed_om_cost_charge_per_mwyr, default_zero)
 end
 start_cost_per_mw(r::AbstractResource) = get(r, :start_cost_per_mw, default_zero)
+mw_s_per_mw(r::AbstractResource) = get(r, :mw_s_per_mw, default_zero)
 
 # fuel
 fuel(r::AbstractResource) = get(r, :fuel, "None")

--- a/src/model/resources/thermal/thermal.jl
+++ b/src/model/resources/thermal/thermal.jl
@@ -37,6 +37,7 @@ function thermal!(EP::Model, inputs::Dict, setup::Dict)
             for y in THERM_ALL))
         add_similar_to_expression!(EP[:eCapResMarBalance], eCapResMarBalanceThermal)
 
+
         if !isempty(intersect(MAINT, THERM_COMMIT))
             thermal_maintenance_capacity_reserve_margin_adjustment!(EP, inputs)
         end
@@ -45,6 +46,8 @@ function thermal!(EP::Model, inputs::Dict, setup::Dict)
             fusion_capacity_reserve_margin_adjustment!(EP, inputs)
         end
     end
+
+
 
     if setup["EnergyShareRequirement"] > 0
         if !isempty(intersect(FUSION, THERM_COMMIT))

--- a/src/time_domain_reduction/time_domain_reduction.jl
+++ b/src/time_domain_reduction/time_domain_reduction.jl
@@ -1351,6 +1351,27 @@ function cluster_inputs(inpath,
                 CSV.write(joinpath(inpath, "inputs", Stage_Outfiles[per]["Fuel"]),
                     NewFuelOutput)
 
+                inertia_path = joinpath(inpath,
+                    "inputs",
+                    "inputs_p$per",
+                    mysetup["PoliciesFolder"],
+                    "inertia_req.csv")
+                if isfile(inertia_path)
+                    inertia_df = CSV.read(inertia_path, DataFrame)
+                    req = inertia_df[:, :MW_s]
+                    new_req = Float64[]
+                    for c in M
+                        append!(new_req,
+                            req[((c - 1) * TimestepsPerRepPeriod + 1):(c * TimestepsPerRepPeriod)])
+                    end
+                    outpath = joinpath(inpath,
+                        "inputs",
+                        Stage_Outfiles[per]["Fuel"])
+                    tdr_stage = dirname(outpath)
+                    CSV.write(joinpath(tdr_stage, "inertia_req.csv"),
+                        DataFrame(MW_s = new_req))
+                end
+
                 ### TDR_Results/Period_map.csv
                 if v
                     println("Writing period map...")
@@ -1497,6 +1518,23 @@ function cluster_inputs(inpath,
             CSV.write(joinpath(inpath, "inputs", input_stage_directory, Fuel_Outfile),
                 NewFuelOutput)
 
+            inertia_path = joinpath(inpath,
+                "inputs",
+                input_stage_directory,
+                mysetup["PoliciesFolder"],
+                "inertia_req.csv")
+            if isfile(inertia_path)
+                inertia_df = CSV.read(inertia_path, DataFrame)
+                req = inertia_df[:, :MW_s]
+                new_req = Float64[]
+                for c in M
+                    append!(new_req,
+                        req[((c - 1) * TimestepsPerRepPeriod + 1):(c * TimestepsPerRepPeriod)])
+                end
+                tdr_stage = joinpath(inpath, "inputs", input_stage_directory, TimeDomainReductionFolder)
+                CSV.write(joinpath(tdr_stage, "inertia_req.csv"), DataFrame(MW_s = new_req))
+            end
+
             ### Period_map.csv
             if v
                 println("Writing period map...")
@@ -1611,6 +1649,19 @@ function cluster_inputs(inpath,
             println("Writing fuel profiles...")
         end
         CSV.write(joinpath(inpath, Fuel_Outfile), NewFuelOutput)
+
+        ### TDR_Results/inertia_req.csv
+        inertia_path = joinpath(inpath, mysetup["PoliciesFolder"], "inertia_req.csv")
+        if isfile(inertia_path)
+            inertia_df = CSV.read(inertia_path, DataFrame)
+            req = inertia_df[:, :MW_s]
+            new_req = Float64[]
+            for c in M
+                append!(new_req, req[((c - 1) * TimestepsPerRepPeriod + 1):(c * TimestepsPerRepPeriod)])
+            end
+            CSV.write(joinpath(inpath, TimeDomainReductionFolder, "inertia_req.csv"),
+                DataFrame(MW_s = new_req))
+        end
 
         ### TDR_Results/Period_map.csv
         if v

--- a/src/write_outputs/write_inertia.jl
+++ b/src/write_outputs/write_inertia.jl
@@ -32,6 +32,8 @@ function write_inertia(path::AbstractString, inputs::Dict, setup::Dict, EP::Mode
     end
 
     df = DataFrame(Resource = resources, Zone = zones, AnnualSum = inertia * weight)
-    write_temporal_data(df, inertia, path, setup, "inertia")
-    return nothing
+    # write_temporal_data(df, inertia, path, setup, "inertia")
+    CSV.write(joinpath(path, "inertia.csv"), df)
+    return df
+    # return nothing
 end

--- a/src/write_outputs/write_inertia.jl
+++ b/src/write_outputs/write_inertia.jl
@@ -1,0 +1,25 @@
+function write_inertia(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+    gen = inputs["RESOURCES"]
+    G = inputs["G"]
+    names = inputs["RESOURCE_NAMES"]
+    zones = inputs["R_ZONES"]
+    COMMIT = inputs["COMMIT"]
+    T = inputs["T"]
+    scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1.0
+    avail = inputs["pP_Max"]
+    data = zeros(G, T)
+    for y in COMMIT
+        data[y, :] .=
+            value.(EP[:vCOMMIT][y, :] .* cap_size(gen[y]) .* avail[y, :] .*
+                   scale_factor .* mw_s_per_mw(gen[y]))
+    end
+    NON_COMMIT = setdiff(1:G, COMMIT)
+    for y in NON_COMMIT
+        data[y, :] .= value.(EP[:eTotalCap][y]) .* avail[y, :] .* scale_factor .*
+                       mw_s_per_mw(gen[y])
+    end
+    df = DataFrame(Resource = names, Zone = zones)
+    df.AnnualSum = data * inputs["omega"]
+    write_temporal_data(df, data, path, setup, "inertia")
+    return nothing
+end

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -437,6 +437,15 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
             println(elapsed_time_max_cap_req)
         end
 
+        if setup["InertiaRequirement"] == 1 && output_settings_d["WriteInertia"]
+            elapsed_time_inertia = @elapsed write_inertia(path,
+                inputs,
+                setup,
+                EP)
+            println("Time elapsed for writing inertia is")
+            println(elapsed_time_inertia)
+        end
+
         if setup["HydrogenMinimumProduction"] == 1 && has_duals(EP)
             if output_settings_d["WriteHydrogenPrices"]
                 elapsed_time_hydrogen_prices = @elapsed write_hydrogen_prices(path,

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -437,7 +437,7 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
             println(elapsed_time_max_cap_req)
         end
 
-        if setup["InertiaRequirement"] == 1 && output_settings_d["WriteInertia"]
+        if output_settings_d["WriteInertia"]
             elapsed_time_inertia = @elapsed write_inertia(path,
                 inputs,
                 setup,

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -44,7 +44,10 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
         end
     end
 
-    # Dict containing the list of outputs to write
+    # Dict containing the list of outputs to write.  The configuration
+    # routine populates this dictionary with Boolean flags for each
+    # output file, and we reference it throughout this function to
+    # determine which files to produce.
     output_settings_d = setup["WriteOutputsSettingsDict"]
     write_settings_file(path, setup)
     write_system_env_summary(path)


### PR DESCRIPTION
## Summary
- add new config flag `InertiaRequirement` and output flag `WriteInertia`
- load inertia requirements from `inertia_req.csv`
- implement inertia balance expressions and constraint
- record inertia contributions from committed thermal generators
- output hourly inertia
- document `inertia_req.csv` structure
- include availability factors when calculating hourly inertia

## Testing
- ❌ `julia -e 'using JuliaFormatter; format(".")'` (failed to run: `bash: julia: command not found`)
- ❌ `julia --project=test -e 'using Pkg; Pkg.test()'` (failed to run: `bash: julia: command not found`)


------
https://chatgpt.com/codex/tasks/task_b_6840b0564cf4832985b4f7c673684517