### PR TITLE
Allow price output when multistage is active

### DIFF
--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -265,6 +265,13 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
         println(elapsed_time_angles)
     end
 
+    # Write price outputs regardless of multi-stage configuration
+    if has_duals(EP) == 1 && output_settings_d["WritePrice"]
+        elapsed_time_price = @elapsed write_price(path, inputs, setup, EP)
+        println("Time elapsed for writing price is")
+        println(elapsed_time_price)
+    end
+
     # Temporary! Suppress these outputs until we know that they are compatable with multi-stage modeling
     if setup["MultiStage"] == 0
         dfEnergyRevenue = DataFrame()
@@ -272,11 +279,6 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
         dfSubRevenue = DataFrame()
         dfRegSubRevenue = DataFrame()
         if has_duals(EP) == 1
-            if output_settings_d["WritePrice"]
-                elapsed_time_price = @elapsed write_price(path, inputs, setup, EP)
-                println("Time elapsed for writing price is")
-                println(elapsed_time_price)
-            end
 
             if output_settings_d["WriteEnergyRevenue"] ||
                output_settings_d["WriteNetRevenue"]


### PR DESCRIPTION
## Summary
- write prices even when `MultiStage` is enabled

## Testing
- `julia -e 'using Pkg; Pkg.test()'` *(fails: `julia` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841c4b122788329a222a3ed6b78a023