### PR TITLE
Add inertia requirement setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ There are two ways to run GenX with either type of solver options (open-source f
 
 Detailed documentation for GenX can be found [here](https://genxproject.github.io/GenX.jl/dev).
 It includes details of each of GenX's methods, required and optional input files, and outputs.
+The inputs now require an additional `MW_s_per_MW` column in each resource file to
+specify inertia contribution per MW of installed capacity. For each period a
+`policies/inertia_req.csv` file with a `MW_s` column may be provided to set
+hourly system inertia requirements. Enable this feature by setting
+`InertiaRequirement: 1` in `genx_settings.yml`.
 Interested users may also want to browse through [prior publications](https://energy.mit.edu/genx/#publications) that have used GenX to understand the various features of the tool.
 
 

--- a/docs/src/User_Guide/model_configuration.md
+++ b/docs/src/User_Guide/model_configuration.md
@@ -84,8 +84,11 @@ The following tables summarize the model settings parameters and their default/p
 |MaxCapReq | Maximum system-wide technology capacity limit constraints.|
 || 1 = if one or more maximum technology capacity constraints are specified|
 || 0 = otherwise|
-|HydrogenMinimumProduction | Hydrogen production requirements from electrolyzers.|
-|1 = Constraint is active.|
+|HydrogenMinimumProduction | Hydrogen production requirements from electrolyzers.| 
+|1 = Constraint is active.| 
+||0 = Constraint is not active.| 
+|InertiaRequirement | Enforce system inertia requirement.| 
+||1 = Constraint is active if unit commitment is used.| 
 ||0 = Constraint is not active.| 
 
 ## 4. Network related

--- a/docs/src/User_Guide/model_input.md
+++ b/docs/src/User_Guide/model_input.md
@@ -16,7 +16,7 @@ All input files are in CSV format. Running the GenX model requires a minimum of 
 <ol start="3">
     <li>Demand_data.csv: specify time-series of demand profiles for each model zone, weights for each time step, demand shedding costs, and optional time domain reduction parameters.</li>
     <li>Generators_variability.csv: specify time-series of capacity factor/availability for each resource.</li>
-    <li>Resources folder: specify cost and performance data for generation, storage and demand flexibility resources.</li>
+    <li>Resources folder: specify cost and performance data for generation, storage and demand flexibility resources. Each resource file must include a column `MW_s_per_MW` describing its inertia contribution per MW.</li>
 </ol>
 ```
  
@@ -30,6 +30,7 @@ Additionally, the user may need to specify eight more **settings-specific** inpu
 7. Vre\_and\_stor\_solar\_variability.csv: specify time-series of capacity factor/availability for each solar PV resource that exists for every co-located VRE and storage resource (in DC terms).
 8. Vre\_and\_stor\_wind\_variability.csv: specify time-series of capacity factor/availability for each wind resource that exists for every co-located VRE and storage resource (in AC terms).
 9. Hydrogen\_demand.csv: specify regional hydrogen production requirements.
+10. inertia\_req.csv: specify hourly system inertia requirement in MW·s for each period. Use when `InertiaRequirement` is set to 1.
 
 
 !!! note "Note"

--- a/docs/src/User_Guide/model_output.md
+++ b/docs/src/User_Guide/model_output.md
@@ -109,6 +109,11 @@ This file summarizes the cost, revenue and profit for each generation technology
 | Cost| Total Cost. |$ |
 | Profit |Revenue minus Cost. |$ |
 
+### 1.10 hourly_inertia.csv
+
+Reports system inertia for each modeled hour. This file is written when
+`InertiaRequirement` is active and `WriteInertia` is enabled.
+
 ## 2 Settings-specific outputs
 
 This section includes the output files that GenX will print if corresponding function is specified in the Settings.

--- a/example_systems/10_IEEE_9_bus_DC_OPF/settings/genx_settings.yml
+++ b/example_systems/10_IEEE_9_bus_DC_OPF/settings/genx_settings.yml
@@ -8,5 +8,6 @@ StorageLosses: 0 # Energy Share Requirement and CO2 constraints account for ener
 MinCapReq: 0  # Activate minimum technology carveout constraints; 0 = not active; 1 = active
 MaxCapReq: 0  # Activate maximum technology carveout constraints; 0 = not active; 1 = active
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
+InertiaRequirement: 0
 DC_OPF: 1 #Flag for running DC-OPF: 0 = not active (transport model); 1 = active
 WriteOutputs: "annual"

--- a/example_systems/1_three_zones/settings/genx_settings.yml
+++ b/example_systems/1_three_zones/settings/genx_settings.yml
@@ -9,5 +9,6 @@ MaxCapReq: 0  # Activate maximum technology carveout constraints; 0 = not active
 ParameterScale: 1 # Turn on parameter scaling wherein demand, capacity and power variables are defined in GW rather than MW. 0 = not active; 1 = active systemwide
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
+InertiaRequirement: 0
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Demand_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)
 OutputFullTimeSeries: 1

--- a/example_systems/2_three_zones_w_electrolyzer/settings/genx_settings.yml
+++ b/example_systems/2_three_zones_w_electrolyzer/settings/genx_settings.yml
@@ -1,5 +1,6 @@
 Trans_Loss_Segments: 1 # Number of segments used in piecewise linear approximation of transmission losses; 1 = linear, >2 = piecewise quadratic
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
+InertiaRequirement: 0
 StorageLosses: 1 # Energy Share Requirement and CO2 constraints account for energy lost; 0 = not active (DO NOT account for energy lost); 1 = active systemwide (DO account for energy lost)
 HydrogenHourlyMatching: 1 # Hydrogen electrolyzer contribution to hourly supply matching required
 ParameterScale: 1 # Turn on parameter scaling wherein demand, capacity and power variables are defined in GW rather than MW. 0 = not active; 1 = active systemwide

--- a/example_systems/3_three_zones_w_co2_capture/settings/genx_settings.yml
+++ b/example_systems/3_three_zones_w_co2_capture/settings/genx_settings.yml
@@ -9,5 +9,6 @@ MaxCapReq: 0  # Activate maximum technology carveout constraints; 0 = not active
 ParameterScale: 1 # Turn on parameter scaling wherein demand, capacity and power variables are defined in GW rather than MW. 0 = not active; 1 = active systemwide
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
+InertiaRequirement: 0
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Demand_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered) 
 LDSAdditionalConstraints: 1 # Activate additional constraints to prevent violation of SoC limits in non-representative periods; 0 = not active; 1 = active

--- a/example_systems/4_three_zones_w_policies_slack/settings/genx_settings.yml
+++ b/example_systems/4_three_zones_w_policies_slack/settings/genx_settings.yml
@@ -9,4 +9,5 @@ MaxCapReq: 1  # Activate maximum technology carveout constraints; 0 = not active
 ParameterScale: 1 # Turn on parameter scaling wherein demand, capacity and power variables are defined in GW rather than MW. 0 = not active; 1 = active systemwide
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
+InertiaRequirement: 0
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Demand_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)

--- a/example_systems/5_three_zones_w_piecewise_fuel/settings/genx_settings.yml
+++ b/example_systems/5_three_zones_w_piecewise_fuel/settings/genx_settings.yml
@@ -10,4 +10,5 @@ MaxCapReq: 0  # Activate maximum technology carveout constraints; 0 = not active
 ParameterScale: 1 # Turn on parameter scaling wherein demand, capacity and power variables are defined in GW rather than MW. 0 = not active; 1 = active systemwide
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
+InertiaRequirement: 0
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Demand_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)

--- a/example_systems/6_three_zones_w_multistage/settings/genx_settings.yml
+++ b/example_systems/6_three_zones_w_multistage/settings/genx_settings.yml
@@ -8,5 +8,6 @@ MinCapReq: 0  # Activate minimum technology carveout constraints; 0 = not active
 MaxCapReq: 0  # Activate maximum technology carveout constraints; 0 = not active; 1 = active
 ParameterScale: 1 # Turn on parameter scaling wherein demand, capacity and power variables are defined in GW rather than MW. 0 = not active; 1 = active systemwide
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
+InertiaRequirement: 0
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Demand_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)
 MultiStage: 1 # 0 = Single-stage GenX, 1 = Multi-stage GenX

--- a/example_systems/7_three_zones_w_colocated_VRE_storage/settings/genx_settings.yml
+++ b/example_systems/7_three_zones_w_colocated_VRE_storage/settings/genx_settings.yml
@@ -2,6 +2,7 @@ ParameterScale: 1
 NetworkExpansion: 1
 Trans_Loss_Segments: 1
 UCommit: 2
+InertiaRequirement: 0
 StorageLosses: 1
 CO2Cap: 1
 MinCapReq: 1

--- a/example_systems/8_three_zones_w_colocated_VRE_storage_electrolyzers/settings/genx_settings.yml
+++ b/example_systems/8_three_zones_w_colocated_VRE_storage_electrolyzers/settings/genx_settings.yml
@@ -1,5 +1,6 @@
 Trans_Loss_Segments: 1 # Number of segments used in piecewise linear approximation of transmission losses; 1 = linear, >2 = piecewise quadratic
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
+InertiaRequirement: 0
 StorageLosses: 1 # Energy Share Requirement and CO2 constraints account for energy lost; 0 = not active (DO NOT account for energy lost); 1 = active systemwide (DO account for energy lost)
 HydrogenHourlyMatching: 0 # Hydrogen electrolyzer hourly supply matching required
 ParameterScale: 0 # Turn on parameter scaling wherein demand, capacity and power variables are defined in GW rather than MW. 0 = not active; 1 = active systemwide

--- a/example_systems/9_three_zones_w_retrofit/settings/genx_settings.yml
+++ b/example_systems/9_three_zones_w_retrofit/settings/genx_settings.yml
@@ -9,4 +9,5 @@ MaxCapReq: 0  # Activate maximum technology carveout constraints; 0 = not active
 ParameterScale: 1 # Turn on parameter scaling wherein demand, capacity and power variables are defined in GW rather than MW. 0 = not active; 1 = active systemwide
 WriteShadowPrices: 1 # Write shadow prices of LP or relaxed MILP; 0 = not active; 1 = active
 UCommit: 2 # Unit committment of thermal power plants; 0 = not active; 1 = active using integer clestering; 2 = active using linearized clustering
+InertiaRequirement: 0
 TimeDomainReduction: 1 # Time domain reduce (i.e. cluster) inputs based on Demand_data.csv, Generators_variability.csv, and Fuels_data.csv; 0 = not active (use input data as provided); 0 = active (cluster input data, or use data that has already been clustered)

--- a/src/configure_settings/configure_settings.jl
+++ b/src/configure_settings/configure_settings.jl
@@ -15,6 +15,7 @@ function default_settings()
         "ParameterScale" => 0,
         "WriteShadowPrices" => 0,
         "UCommit" => 0,
+        "InertiaRequirement" => 0,
         "TimeDomainReduction" => 0,
         "TimeDomainReductionFolder" => "TDR_results",
         "OutputFullTimeSeries" => 0,
@@ -115,6 +116,7 @@ function default_writeoutput()
         "WriteFusion" => true,
         "WriteHourlyMatchingPrices" => true,
         "WriteHydrogenPrices" => true,
+        "WriteInertia" => true,
         "WriteMaintenance" => true,
         "WriteMaxCapReq" => true,
         "WriteMinCapReq" => true,
@@ -162,6 +164,7 @@ function configure_writeoutput(output_settings_path::String, settings::Dict)
         writeoutput["WriteReserveMarginWithWeights"] = false
         writeoutput["WriteAngles"] = false
         writeoutput["WriteTransmissionFlows"] = false
+        writeoutput["WriteInertia"] = false
     end
 
     # read in YAML file if provided

--- a/src/load_inputs/load_inertia_req.jl
+++ b/src/load_inputs/load_inertia_req.jl
@@ -5,8 +5,9 @@ function load_inertia_req!(setup::Dict, path::AbstractString, inputs::Dict)
         return nothing
     end
     df = load_dataframe(joinpath(path, filename))
+    rename!(df, lowercase.(names(df)))
     validate_df_cols(df, filename, ["mw_s"])
-    inputs["InertiaReq"] = collect(skipmissing(df.MW_s))
+    inputs["InertiaReq"] = collect(skipmissing(df.mw_s))
     println(filename * " Successfully Read!")
     return nothing
 end

--- a/src/load_inputs/load_inertia_req.jl
+++ b/src/load_inputs/load_inertia_req.jl
@@ -1,0 +1,12 @@
+function load_inertia_req!(setup::Dict, path::AbstractString, inputs::Dict)
+    filename = "inertia_req.csv"
+    if !isfile(joinpath(path, filename))
+        @info "$(filename) not found. Skipping inertia requirement loading"
+        return nothing
+    end
+    df = load_dataframe(joinpath(path, filename))
+    validate_df_cols(df, filename, ["mw_s"])
+    inputs["InertiaReq"] = collect(skipmissing(df.MW_s))
+    println(filename * " Successfully Read!")
+    return nothing
+end

--- a/src/load_inputs/load_inputs.jl
+++ b/src/load_inputs/load_inputs.jl
@@ -75,6 +75,11 @@ function load_inputs(setup::Dict, path::AbstractString)
         load_hydrogen_demand!(setup, policies_path, inputs)
     end
 
+    # Read in system inertia requirement if activated and unit commitment is active
+    if setup["InertiaRequirement"] >= 1 && setup["UCommit"] >= 1
+        load_inertia_req!(setup, policies_path, inputs)
+    end
+
     # Read in mapping of modeled periods to representative periods
     if is_period_map_necessary(inputs) && is_period_map_exist(setup, path)
         load_period_map!(setup, path, inputs)

--- a/src/load_inputs/load_resources_data.jl
+++ b/src/load_inputs/load_resources_data.jl
@@ -224,6 +224,7 @@ function load_resource_df(path::AbstractString, scale_factor::Float64, resource_
     resource_in = load_dataframe(path)
     # rename columns lowercase for internal consistency
     rename!(resource_in, lowercase.(names(resource_in)))
+    validate_df_cols(resource_in, basename(path), ["mw_s_per_mw"])
     scale_resources_data!(resource_in, scale_factor)
     # scale vre_stor columns if necessary
     resource_type == VreStorage && scale_vre_stor_data!(resource_in, scale_factor)

--- a/src/write_outputs/write_inertia.jl
+++ b/src/write_outputs/write_inertia.jl
@@ -1,0 +1,10 @@
+function write_inertia(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+    if !haskey(inputs, "InertiaReq")
+        @info "No inertia data to write"
+        return nothing
+    end
+    inertia = value.(EP[:eInertia])
+    df = DataFrame(Inertia_MW_s = inertia)
+    CSV.write(joinpath(path, "hourly_inertia.csv"), df)
+    return nothing
+end

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -115,6 +115,12 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
         println(elapsed_time_power_balance)
     end
 
+    if output_settings_d["WriteInertia"] && setup["InertiaRequirement"] >= 1 && setup["UCommit"] >= 1
+        elapsed_time_inertia = @elapsed write_inertia(path, inputs, setup, EP)
+        println("Time elapsed for writing inertia is")
+        println(elapsed_time_inertia)
+    end
+
     if inputs["Z"] > 1
         if output_settings_d["WriteTransmissionFlows"]
             elapsed_time_flows = @elapsed write_transmission_flows(path, inputs, setup, EP)


### PR DESCRIPTION
## Summary
- document how to enable inertia requirement in README and docs
- clarify inertia_req.csv usage in user guide
- describe new InertiaRequirement flag in configuration docs
- include hourly_inertia.csv in outputs documentation
- gate inertia loading and writing behind new flag
- add InertiaRequirement: 0 to all example settings

## Testing
- `julia --project=test -e 'using Pkg; Pkg.test()'` *(fails: julia not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841ebfd8afc8329a68d0ba9d003d209